### PR TITLE
[COR-1819] Fix queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>br.com.monkey.ecx</groupId>
     <artifactId>monkey-mongodb-search</artifactId>
-    <version>2.0</version>
+    <version>2.0.1</version>
     <name>monkey-mongodb-search</name>
     <description>Monkey MongoDB Search</description>
     <properties>

--- a/src/main/java/br/com/monkey/ecx/core/MongoIdGenerator.java
+++ b/src/main/java/br/com/monkey/ecx/core/MongoIdGenerator.java
@@ -1,0 +1,11 @@
+package br.com.monkey.ecx.core;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class MongoIdGenerator {
+
+	public static String generateId() {
+		return RandomStringUtils.random(10, true, true);
+	}
+
+}

--- a/src/main/java/br/com/monkey/ecx/criteria/MonkeyCriteria.java
+++ b/src/main/java/br/com/monkey/ecx/criteria/MonkeyCriteria.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.geo.GeoJson;
 import org.springframework.data.mongodb.core.geo.Sphere;
 import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.GeoCommand;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.schema.JsonSchemaObject.Type;
 import org.springframework.data.mongodb.core.schema.JsonSchemaProperty;
 import org.springframework.data.mongodb.core.schema.MongoJsonSchema;
@@ -67,7 +68,12 @@ public class MonkeyCriteria implements CriteriaDefinition {
 	 */
 	private static final Object NOT_SET = new Object();
 
+	private static final String DEFAULT_PRIORITY_GROUP = "DEFAULT";
+
 	private @Nullable String key;
+
+	@Getter
+	private String priorityGroup = DEFAULT_PRIORITY_GROUP;
 
 	private List<MonkeyCriteria> criteriaChain;
 
@@ -80,16 +86,6 @@ public class MonkeyCriteria implements CriteriaDefinition {
 
 	@Getter
 	private Set<MonkeyCriteria> criteriaOrClause = new HashSet<>();
-
-	public MonkeyCriteria addAndClause(MonkeyCriteria criteria) {
-		this.criteriaAndClause.add(criteria);
-		return this;
-	}
-
-	public MonkeyCriteria addOrClause(MonkeyCriteria criteria) {
-		this.criteriaOrClause.add(criteria);
-		return this;
-	}
 
 	public MonkeyCriteria() {
 		this.criteriaChain = new ArrayList<MonkeyCriteria>();
@@ -105,6 +101,26 @@ public class MonkeyCriteria implements CriteriaDefinition {
 		this.criteriaChain = criteriaChain;
 		this.criteriaChain.add(this);
 		this.key = key;
+	}
+
+	public MonkeyCriteria addAndClause(MonkeyCriteria criteria) {
+		this.criteriaAndClause.add(criteria);
+		return this;
+	}
+
+	public MonkeyCriteria addOrClause(MonkeyCriteria criteria) {
+		this.criteriaOrClause.add(criteria);
+		return this;
+	}
+
+	public MonkeyCriteria withPriorityGroup(String id) {
+		this.criteriaAndClause.forEach(item -> item.priorityGroup = id);
+		this.criteriaOrClause.forEach(item -> item.priorityGroup = id);
+		return this;
+	}
+
+	public boolean isDefaultPriorityGroup() {
+		return this.priorityGroup.equals(DEFAULT_PRIORITY_GROUP);
 	}
 
 	/**

--- a/src/main/java/br/com/monkey/ecx/parser/CriteriaParser.java
+++ b/src/main/java/br/com/monkey/ecx/parser/CriteriaParser.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.stream.Collectors.groupingBy;
-import static org.springframework.util.CollectionUtils.isEmpty;
 
 public class CriteriaParser<T> {
 
@@ -29,9 +28,6 @@ public class CriteriaParser<T> {
 
 		if (criteriaList.isEmpty()) {
 			return new Query(criteria);
-		}
-		else if (isEmpty(criteria.getCriteriaAndClause())) {
-			return new Query(new MonkeyCriteria().orOperator(criteriaList));
 		}
 		else {
 			return new Query(new MonkeyCriteria().andOperator(criteriaList));

--- a/src/main/java/br/com/monkey/ecx/parser/CriteriaParser.java
+++ b/src/main/java/br/com/monkey/ecx/parser/CriteriaParser.java
@@ -6,31 +6,36 @@ import br.com.monkey.ecx.criteria.MonkeyCriteria;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.groupingBy;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 public class CriteriaParser<T> {
 
 	private final QueryVisitor<T> visitor = new QueryVisitor<>();
 
 	public Query parse(String search) {
-		QueryParser parser = getParser(search);
-		MonkeyCriteria visit = visitor.visit(parser.input());
-		MonkeyCriteria monkeyCriteria = new MonkeyCriteria();
-		if (!CollectionUtils.isEmpty(visit.getCriteriaOrClause())
-				&& !CollectionUtils.isEmpty(visit.getCriteriaAndClause())) {
-			monkeyCriteria = new MonkeyCriteria().andOperator(visit.getCriteriaAndClause())
-					.orOperator(visit.getCriteriaOrClause());
+		MonkeyCriteria criteria = visitor.visit(getParser(search).input());
+		List<MonkeyCriteria> criteriaList = new ArrayList<>();
+
+		criteria.getCriteriaOrClause().stream().collect(groupingBy(MonkeyCriteria::getPriorityGroup))
+				.forEach((key, value) -> criteriaList.add(new MonkeyCriteria().orOperator(value)));
+
+		criteria.getCriteriaAndClause().stream().collect(groupingBy(MonkeyCriteria::getPriorityGroup))
+				.forEach((key, value) -> criteriaList.add(new MonkeyCriteria().andOperator(value)));
+
+		if (criteriaList.isEmpty()) {
+			return new Query(criteria);
 		}
-		else if (!CollectionUtils.isEmpty(visit.getCriteriaAndClause())) {
-			monkeyCriteria = new MonkeyCriteria().andOperator(visit.getCriteriaAndClause());
+		else if (isEmpty(criteria.getCriteriaAndClause())) {
+			return new Query(new MonkeyCriteria().orOperator(criteriaList));
 		}
-		else if (!CollectionUtils.isEmpty(visit.getCriteriaOrClause())) {
-			monkeyCriteria = new MonkeyCriteria().orOperator(visit.getCriteriaOrClause());
+		else {
+			return new Query(new MonkeyCriteria().andOperator(criteriaList));
 		}
-		else if (!visit.getCriteriaObject().isEmpty()) {
-			return new Query(visit);
-		}
-		return new Query(monkeyCriteria);
 	}
 
 	private QueryParser getParser(String search) {

--- a/src/main/java/br/com/monkey/ecx/parser/QueryVisitor.java
+++ b/src/main/java/br/com/monkey/ecx/parser/QueryVisitor.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static br.com.monkey.ecx.core.MongoIdGenerator.generateId;
 import static br.com.monkey.ecx.criteria.SearchOperation.*;
 import static java.util.Objects.nonNull;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -51,7 +52,7 @@ class QueryVisitor<T> extends QueryBaseVisitor<MonkeyCriteria> {
 
 	@Override
 	public MonkeyCriteria visitPriorityQuery(QueryParser.PriorityQueryContext ctx) {
-		return visit(ctx.query());
+		return visit(ctx.query()).withPriorityGroup(generateId());
 	}
 
 	@Override
@@ -68,7 +69,9 @@ class QueryVisitor<T> extends QueryBaseVisitor<MonkeyCriteria> {
 			}
 			right.getCriteriaOrClause().forEach(left::addOrClause);
 			right.getCriteriaAndClause().forEach(left::addAndClause);
-			left.addAndClause(right);
+			if (right.isDefaultPriorityGroup()) {
+				left.addAndClause(right);
+			}
 			criteria = new MonkeyCriteria();
 			left.getCriteriaOrClause().forEach(criteria::addOrClause);
 			left.getCriteriaAndClause().forEach(criteria::addAndClause);
@@ -80,7 +83,9 @@ class QueryVisitor<T> extends QueryBaseVisitor<MonkeyCriteria> {
 			}
 			right.getCriteriaOrClause().forEach(left::addOrClause);
 			right.getCriteriaAndClause().forEach(left::addAndClause);
-			left.addOrClause(right);
+			if (right.isDefaultPriorityGroup()) {
+				left.addOrClause(right);
+			}
 			criteria = new MonkeyCriteria();
 			left.getCriteriaOrClause().forEach(criteria::addOrClause);
 			left.getCriteriaAndClause().forEach(criteria::addAndClause);
@@ -138,7 +143,7 @@ class QueryVisitor<T> extends QueryBaseVisitor<MonkeyCriteria> {
 				Function<SearchCriteria, MonkeyCriteria> functionCombined = FILTER_CRITERIA
 						.get(condition.getOperation());
 				MonkeyCriteria combined = functionCombined.apply(combinedCriteria);
-				apply.addOrClause(apply).addOrClause(combined);
+				apply.addOrClause(apply).addOrClause(combined).withPriorityGroup(alias.getAlias());
 			});
 		}
 	}


### PR DESCRIPTION
## Tipo da Alteração

- [x] Bugfix
- [ ] New Feature
- [ ] Enhancement
- [ ] Refactoring

## Descrição
Antes da alteração, as queries de search eram montadas apenas agrupando as condições `AND` e `OR` recebidas no parametro `search` da request, sem levar em consideração as condições com prioridade (separadas por parênteses).

Além disso, no processamento do parametro `search`, é usado um conceito de alias, onde, por exemplo, um parâmetro `externalId` recebido na request, é processado para gerar uma condição `OR` entre os campos `requestPayload.externalId OR requestPayload.items.externalId`. Porém, além de criar a condição `OR` entre os alias, também era criada uma condição `AND` apenas com o campo recebido na request. 

Com isso, uma query utilizando alias e o agrupamento simples das condições `AND` e `OR`, gerava resultados errados.

Segue um exemplo de como a query era montada para o seguinte search:

`search=(eventType:CustodyResponseEvent OR eventType:PurchaseFlowCompletedEvent) AND externalId:'*59900000428*'`

- **prioridade:** (eventType:CustodyResponseEvent OR eventType:PurchaseFlowCompletedEvent)
- **alias:** externalId:'*59900000428*'

``` 
{
	"$and":[
		{
			"requestPayload.externalId":{
				"$regularExpression":{
					"pattern":"59900000428",
					"options":""
				}
			}
		}
	],
	"$or":[
		{
			"eventType":"PurchaseFlowCompletedEvent"
		},
		{
			"eventType":"CustodyResponseEvent"
		},
		{
			"requestPayload.externalId":{
				"$regularExpression":{
					"pattern":"59900000428",
					"options":""
				}
			}
		},
		{
			"requestPayload.items.externalId":{
				"$regularExpression":{
					"pattern":"59900000428",
					"options":""
				}
			}
		}
	],
	"program":"sandbox"
}
``` 

Para corrigir a montagem da query, foi necessário agrupar as condições prioritárias e as condições que usam alias.
Assim, a query do exemplo anterior, será montada da seguinte forma:

```
{
	"$and":[
		{
			"$or":[
				{
					"requestPayload.externalId":{
						"$regularExpression":{
							"pattern":"59900000428",
							"options":""
						}
					}
				},
				{
					"requestPayload.items.externalId":{
						"$regularExpression":{
							"pattern":"59900000428",
							"options":""
						}
					}
				}
			]
		},
		{
			"$or":[
				{
					"eventType":"PurchaseFlowCompletedEvent"
				},
				{
					"eventType":"CustodyResponseEvent"
				}
			]
		}
	],
	"program":"sandbox"
}
```

## Como Você Testou a Alteração

**Build**
---
![image](https://github.com/user-attachments/assets/0e1875e8-e9c5-4414-b665-edafa87250d8)

---
- **Chamada sem passar o parâmetro search:**
- Retornam 101 resultados
![image](https://github.com/user-attachments/assets/e5b78f36-4439-4f53-9c8f-ab385b8821e0)


- Executando a query gerada direto na base, também retornam 101 resultados
![image](https://github.com/user-attachments/assets/b7395e4d-3866-48ff-a359-bd129100b6fc)

---
- **Chamada utilizando search simples com apenas um parâmetro de busca:**
- `search=eventType:PurchaseFlowCompletedEvent`
- Retornam 25 resultados
![image](https://github.com/user-attachments/assets/0b981b6c-3b41-4c6e-8bd6-cad7039b3d53)

- Executando a query gerada direto na base, também retornam 25 resultados
![image](https://github.com/user-attachments/assets/10866401-7b81-49c6-a771-a7967d6e1219)

---
- **Chamada utilizando prioridade e alias:**
- `search=(eventType:CustodyResponseEvent OR eventType:PurchaseFlowCompletedEvent) AND invoiceNumber:'*9993*'`
- Retorna apenas 1 resultado
![image](https://github.com/user-attachments/assets/084a4f67-7e61-4953-8e26-a4c5b2c4db71)

- Executando a query gerada direto na base, também retorna apenas 1 resultado
![image](https://github.com/user-attachments/assets/dd8ee6a9-f727-48db-9240-9392dc6216a9)

---
- **Chamada utilizando prioridade e 2 condições para um campo que utiliza alias:**
- `search=(eventType:CustodyResponseEvent OR eventType:PurchaseFlowCompletedEvent) AND invoiceNumber:'*9993*' OR invoiceNumber:'*9992*'`

- retorna 2 resultados
![image](https://github.com/user-attachments/assets/53d3d85b-b141-44ad-a16b-8d95b3accfed)

- Executando a query gerada direto na base, também retornam 2 resultado
![image](https://github.com/user-attachments/assets/8c48708f-709d-44a1-9340-900ef49a640d)

---
