### PR TITLE
[SUB-2006] - Implementation of date and time filters.

### DIFF
--- a/src/main/antlr4/Query.g4
+++ b/src/main/antlr4/Query.g4
@@ -23,7 +23,9 @@ key
    ;
 
 value
-   : IDENTIFIER
+   : DATETIME
+   | DATE
+   | IDENTIFIER
    | STRING
    | ENCODED_STRING
    | NUMBER
@@ -31,7 +33,9 @@ value
    ;
 
 op
-   : EQ
+   : GTE
+   | LTE
+   | EQ
    | GT
    | LT
    | NOT_EQ
@@ -116,12 +120,22 @@ LPAREN
 RPAREN
    : ')'
    ;
+GTE
+   : '>='
+   ;
+
+LTE
+   : '<='
+   ;
+
 GT
    : '>'
    ;
+
 LT
    : '<'
    ;
+
 EQ
    : ':'
    ;
@@ -142,4 +156,19 @@ LineTerminator
 ;
 WS
     : [ \t\r\n]+ -> skip
+   ;
+
+DATETIME
+   : DIGIT DIGIT DIGIT DIGIT '-' DIGIT DIGIT '-' DIGIT DIGIT 'T'
+     DIGIT DIGIT ':' DIGIT DIGIT
+     ( ':' DIGIT DIGIT ( '.' DIGIT+ )? )?
+     ( 'Z' | [+\-] DIGIT DIGIT ':' DIGIT DIGIT )?
+   ;
+
+DATE
+   : DIGIT DIGIT DIGIT DIGIT '-' DIGIT DIGIT '-' DIGIT DIGIT
+   ;
+
+fragment DIGIT
+   : [0-9]
    ;

--- a/src/main/java/br/com/monkey/ecx/core/ValueParser.java
+++ b/src/main/java/br/com/monkey/ecx/core/ValueParser.java
@@ -1,0 +1,138 @@
+package br.com.monkey.ecx.core;
+
+import java.time.*;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+import java.util.regex.Pattern;
+
+import static br.com.monkey.ecx.configuration.MongoDBSearchConfiguration.getInstance;
+import static br.com.monkey.ecx.core.MongoSearchGovernmentIdUtils.isValidGovernmentId;
+
+public class ValueParser {
+
+    static Pattern BOOLEAN = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE);
+
+    static Pattern NUMBER = Pattern.compile("-?\\d+(\\.\\d+)?");
+
+	public static boolean isTemporal(String rawValue) {
+		if (rawValue == null || rawValue.trim().isEmpty()) {
+			return false;
+		}
+		String value = rawValue.trim();
+		return canParseLocalDate(value) || canParseLocalDateTime(value);
+	}
+
+	public static boolean isDateOnly(String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return false;
+		}
+		try {
+			LocalDate.parse(value.trim());
+			return true;
+		}
+		catch (DateTimeParseException e) {
+			return false;
+		}
+	}
+
+	public static boolean isDateTimeToMinute(String value) {
+		if (value == null || value.trim().isEmpty()) {
+			return false;
+		}
+
+		return value.trim().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}$");
+	}
+
+	public static Date startOfMinute(String value) {
+		LocalDateTime localDateTime = LocalDateTime.parse(value.trim());
+		return Date.from(localDateTime.toInstant(ZoneOffset.UTC));
+	}
+
+	public static Date nextMinute(String value) {
+		LocalDateTime localDateTime = LocalDateTime.parse(value.trim()).plusMinutes(1);
+		return Date.from(localDateTime.toInstant(ZoneOffset.UTC));
+	}
+
+	public static Date parseToDate(String rawValue) {
+		String value = rawValue.trim();
+
+		try {
+			LocalDateTime localDateTime = LocalDateTime.parse(value);
+			return Date.from(localDateTime.toInstant(ZoneOffset.UTC));
+		}
+		catch (DateTimeParseException ignored) {
+		}
+
+		try {
+			LocalDate localDate = LocalDate.parse(value);
+			return Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant());
+		}
+		catch (DateTimeParseException ignored) {
+		}
+
+		throw new IllegalArgumentException("Invalid temporal value: " + rawValue);
+	}
+
+	public static Date startOfDay(String value) {
+		LocalDate localDate = LocalDate.parse(value.trim());
+		return Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant());
+	}
+
+	public static Date nextDayStartOfDay(String value) {
+		LocalDate localDate = LocalDate.parse(value.trim()).plusDays(1);
+		return Date.from(localDate.atStartOfDay(ZoneOffset.UTC).toInstant());
+	}
+
+	private static boolean canParseLocalDateTime(String value) {
+		try {
+			LocalDateTime.parse(value);
+			return true;
+		}
+		catch (DateTimeParseException e) {
+			return false;
+		}
+	}
+
+	private static boolean canParseLocalDate(String value) {
+		try {
+			LocalDate.parse(value);
+			return true;
+		}
+		catch (DateTimeParseException e) {
+			return false;
+		}
+	}
+
+    public static Object convertScalarValue(String value) {
+        String monetaryIdentification = getInstance().getMonetaryIdentification();
+
+        if (isValidGovernmentId(value)) {
+            return value;
+        }
+
+        if (value.startsWith(monetaryIdentification)) {
+            return value.replace(monetaryIdentification, "");
+        }
+
+        if (BOOLEAN.matcher(value).matches()) {
+            return Boolean.valueOf(value);
+        }
+
+        if (NUMBER.matcher(value).matches()) {
+            try {
+                return Integer.valueOf(value);
+            }
+            catch (NumberFormatException ignored) {
+            }
+
+            try {
+                return Long.valueOf(value);
+            }
+            catch (NumberFormatException ignored) {
+            }
+            return Double.valueOf(value);
+        }
+        return value;
+    }
+
+}

--- a/src/main/java/br/com/monkey/ecx/core/ValueParser.java
+++ b/src/main/java/br/com/monkey/ecx/core/ValueParser.java
@@ -10,9 +10,9 @@ import static br.com.monkey.ecx.core.MongoSearchGovernmentIdUtils.isValidGovernm
 
 public class ValueParser {
 
-    static Pattern BOOLEAN = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE);
+	static Pattern BOOLEAN = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE);
 
-    static Pattern NUMBER = Pattern.compile("-?\\d+(\\.\\d+)?");
+	static Pattern NUMBER = Pattern.compile("-?\\d+(\\.\\d+)?");
 
 	public static boolean isTemporal(String rawValue) {
 		if (rawValue == null || rawValue.trim().isEmpty()) {
@@ -103,36 +103,36 @@ public class ValueParser {
 		}
 	}
 
-    public static Object convertScalarValue(String value) {
-        String monetaryIdentification = getInstance().getMonetaryIdentification();
+	public static Object convertScalarValue(String value) {
+		String monetaryIdentification = getInstance().getMonetaryIdentification();
 
-        if (isValidGovernmentId(value)) {
-            return value;
-        }
+		if (isValidGovernmentId(value)) {
+			return value;
+		}
 
-        if (value.startsWith(monetaryIdentification)) {
-            return value.replace(monetaryIdentification, "");
-        }
+		if (value.startsWith(monetaryIdentification)) {
+			return value.replace(monetaryIdentification, "");
+		}
 
-        if (BOOLEAN.matcher(value).matches()) {
-            return Boolean.valueOf(value);
-        }
+		if (BOOLEAN.matcher(value).matches()) {
+			return Boolean.valueOf(value);
+		}
 
-        if (NUMBER.matcher(value).matches()) {
-            try {
-                return Integer.valueOf(value);
-            }
-            catch (NumberFormatException ignored) {
-            }
+		if (NUMBER.matcher(value).matches()) {
+			try {
+				return Integer.valueOf(value);
+			}
+			catch (NumberFormatException ignored) {
+			}
 
-            try {
-                return Long.valueOf(value);
-            }
-            catch (NumberFormatException ignored) {
-            }
-            return Double.valueOf(value);
-        }
-        return value;
-    }
+			try {
+				return Long.valueOf(value);
+			}
+			catch (NumberFormatException ignored) {
+			}
+			return Double.valueOf(value);
+		}
+		return value;
+	}
 
 }

--- a/src/main/java/br/com/monkey/ecx/criteria/SearchCriteria.java
+++ b/src/main/java/br/com/monkey/ecx/criteria/SearchCriteria.java
@@ -4,18 +4,12 @@ import br.com.monkey.ecx.core.exception.BadRequestException;
 import lombok.Getter;
 
 import java.io.Serializable;
-import java.util.regex.Pattern;
 
 import static br.com.monkey.ecx.configuration.MongoDBSearchConfiguration.getInstance;
-import static br.com.monkey.ecx.core.MongoSearchGovernmentIdUtils.isValidGovernmentId;
 import static lombok.AccessLevel.NONE;
 
 @Getter
 public class SearchCriteria implements Serializable {
-
-	Pattern BOOLEAN = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE);
-
-	Pattern NUMBER = Pattern.compile("-?\\d+(\\.\\d+)?");
 
 	private String key;
 
@@ -62,23 +56,6 @@ public class SearchCriteria implements Serializable {
 		this.key = key;
 		this.operation = op;
 		this.value = value;
-	}
-
-	public Object getValue() {
-		String monetaryIdentification = getInstance().getMonetaryIdentification();
-		if (isValidGovernmentId(value)) {
-			return value;
-		}
-		if (value.startsWith(monetaryIdentification)) {
-			return value.replace(monetaryIdentification, "");
-		}
-		else if (BOOLEAN.matcher(value).matches()) {
-			return Boolean.valueOf(value);
-		}
-		else if (NUMBER.matcher(value).matches()) {
-			return Double.valueOf(value);
-		}
-		return value;
 	}
 
 	public String getValueAsString() {

--- a/src/main/java/br/com/monkey/ecx/criteria/SearchOperation.java
+++ b/src/main/java/br/com/monkey/ecx/criteria/SearchOperation.java
@@ -2,7 +2,7 @@ package br.com.monkey.ecx.criteria;
 
 public enum SearchOperation {
 
-	EQUAL, NOT, GREATER_THAN_EQUAL, LESS_THAN_EQUAL, CONTAINS, NOT_CONTAINS;
+	EQUAL, NOT, GREATER_THAN, GREATER_THAN_EQUAL, LESS_THAN, LESS_THAN_EQUAL, CONTAINS, NOT_CONTAINS;
 
 	public static final String LIKE = "*";
 

--- a/src/main/java/br/com/monkey/ecx/parser/QueryVisitor.java
+++ b/src/main/java/br/com/monkey/ecx/parser/QueryVisitor.java
@@ -4,18 +4,15 @@ import br.com.monkey.ecx.QueryBaseVisitor;
 import br.com.monkey.ecx.QueryParser;
 import br.com.monkey.ecx.configuration.Alias;
 import br.com.monkey.ecx.configuration.MongoDBSearchConfiguration;
+import br.com.monkey.ecx.core.ValueParser;
 import br.com.monkey.ecx.criteria.MonkeyCriteria;
 import br.com.monkey.ecx.criteria.SearchCriteria;
 import br.com.monkey.ecx.criteria.SearchOperation;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static br.com.monkey.ecx.core.MongoIdGenerator.generateId;
-import static br.com.monkey.ecx.criteria.SearchOperation.*;
 import static java.util.Objects.nonNull;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.hasText;
@@ -23,22 +20,6 @@ import static org.springframework.util.StringUtils.hasText;
 class QueryVisitor<T> extends QueryBaseVisitor<MonkeyCriteria> {
 
 	private final Pattern REGEX = Pattern.compile("^(\\*?)(.+?)(\\*?)$");
-
-	private static final Map<SearchOperation, Function<SearchCriteria, MonkeyCriteria>> FILTER_CRITERIA = new HashMap<>();
-
-	// Create map of filter
-	static {
-		FILTER_CRITERIA.put(EQUAL, condition -> MonkeyCriteria.where(condition.getKey()).is(condition.getValue()));
-		FILTER_CRITERIA.put(NOT, condition -> MonkeyCriteria.where(condition.getKey()).ne(condition.getValue()));
-		FILTER_CRITERIA.put(GREATER_THAN_EQUAL,
-				condition -> MonkeyCriteria.where(condition.getKey()).gte(condition.getValue()));
-		FILTER_CRITERIA.put(LESS_THAN_EQUAL,
-				condition -> MonkeyCriteria.where(condition.getKey()).lte(condition.getValue()));
-		FILTER_CRITERIA.put(CONTAINS,
-				condition -> MonkeyCriteria.where(condition.getKey()).regex(condition.getValueAsString()));
-		FILTER_CRITERIA.put(NOT_CONTAINS,
-				condition -> MonkeyCriteria.where(condition.getKey()).not().regex(condition.getValueAsString()));
-	}
 
 	@Override
 	public MonkeyCriteria visitInput(QueryParser.InputContext ctx) {
@@ -118,31 +99,109 @@ class QueryVisitor<T> extends QueryBaseVisitor<MonkeyCriteria> {
 	}
 
 	private MonkeyCriteria buildCriteria(SearchCriteria condition) {
-		Function<SearchCriteria, MonkeyCriteria> function = FILTER_CRITERIA.get(condition.getOperation());
+		Alias alias = MongoDBSearchConfiguration.getInstance().getAliases().stream()
+				.filter(item -> item.getAlias().equals(condition.getKey())).findFirst().orElse(null);
 
-		if (function == null) {
-			throw new IllegalArgumentException("Invalid function param type: ");
+		String resolvedKey = alias != null ? alias.getKey() : condition.getKey();
+		MonkeyCriteria apply = buildTypedCriteria(resolvedKey, condition.getOperation(), condition.getValueAsString());
+		if (alias != null) {
+			addCombinedCondition(condition, apply, alias);
 		}
-
-		MonkeyCriteria apply = function.apply(condition);
-
-		MongoDBSearchConfiguration.getInstance().getAliases().stream()
-				.filter(alias -> alias.getAlias().equals(apply.getKey())).findFirst().ifPresent(alias -> {
-					apply.setKey(alias.getKey());
-					addCombinedCondition(condition, apply, alias);
-				});
-
 		return apply;
 	}
 
-	private static void addCombinedCondition(SearchCriteria condition, MonkeyCriteria apply, Alias alias) {
+	private MonkeyCriteria buildTypedCriteria(String key, SearchOperation operation, String value) {
+		if (ValueParser.isTemporal(value)) {
+			return buildTemporalCriteria(key, operation, value);
+		}
+		return buildDefaultCriteria(key, operation, value);
+	}
+
+	private MonkeyCriteria buildTemporalCriteria(String key, SearchOperation operation, String value) {
+		switch (operation) {
+		case EQUAL:
+			if (ValueParser.isDateOnly(value)) {
+				return new MonkeyCriteria().andOperator(
+						MonkeyCriteria.where(key).gte(ValueParser.startOfDay(value)),
+						MonkeyCriteria.where(key).lt(ValueParser.nextDayStartOfDay(value)));
+			}
+
+			if (ValueParser.isDateTimeToMinute(value)) {
+				return new MonkeyCriteria().andOperator(
+						MonkeyCriteria.where(key).gte(ValueParser.startOfMinute(value)),
+						MonkeyCriteria.where(key).lt(ValueParser.nextMinute(value)));
+			}
+			return MonkeyCriteria.where(key).is(ValueParser.parseToDate(value));
+
+		case NOT:
+			if (ValueParser.isDateOnly(value)) {
+				return new MonkeyCriteria().orOperator(
+						MonkeyCriteria.where(key).lt(ValueParser.startOfDay(value)),
+						MonkeyCriteria.where(key).gte(ValueParser.nextDayStartOfDay(value)));
+			}
+			return MonkeyCriteria.where(key).ne(ValueParser.parseToDate(value));
+
+		case GREATER_THAN:
+			if (ValueParser.isDateOnly(value)) {
+				return MonkeyCriteria.where(key).gt(ValueParser.startOfDay(value));
+			}
+			return MonkeyCriteria.where(key).gt(ValueParser.parseToDate(value));
+
+		case GREATER_THAN_EQUAL:
+			if (ValueParser.isDateOnly(value)) {
+				return MonkeyCriteria.where(key).gte(ValueParser.startOfDay(value));
+			}
+			return MonkeyCriteria.where(key).gte(ValueParser.parseToDate(value));
+
+		case LESS_THAN:
+			if (ValueParser.isDateOnly(value)) {
+				return MonkeyCriteria.where(key).lt(ValueParser.startOfDay(value));
+			}
+			return MonkeyCriteria.where(key).lt(ValueParser.parseToDate(value));
+
+		case LESS_THAN_EQUAL:
+			if (ValueParser.isDateOnly(value)) {
+				return MonkeyCriteria.where(key).lt(ValueParser.nextDayStartOfDay(value));
+			}
+
+			return MonkeyCriteria.where(key).lte(ValueParser.parseToDate(value));
+
+		default:
+			throw new IllegalArgumentException("Temporal operation not supported: " + operation);
+		}
+	}
+
+	private MonkeyCriteria buildDefaultCriteria(String key, SearchOperation operation, String rawValue) {
+		Object value = ValueParser.convertScalarValue(rawValue);
+		switch (operation) {
+		case EQUAL:
+			return MonkeyCriteria.where(key).is(value);
+		case NOT:
+			return MonkeyCriteria.where(key).ne(value);
+		case GREATER_THAN:
+			return MonkeyCriteria.where(key).gt(value);
+		case GREATER_THAN_EQUAL:
+			return MonkeyCriteria.where(key).gte(value);
+		case LESS_THAN:
+			return MonkeyCriteria.where(key).lt(value);
+		case LESS_THAN_EQUAL:
+			return MonkeyCriteria.where(key).lte(value);
+		case CONTAINS:
+			return MonkeyCriteria.where(key).regex(rawValue);
+		case NOT_CONTAINS:
+			return MonkeyCriteria.where(key).not().regex(rawValue);
+		default:
+			throw new IllegalArgumentException("Operation not supported: " + operation);
+
+		}
+
+	}
+
+	private void addCombinedCondition(SearchCriteria condition, MonkeyCriteria apply, Alias alias) {
 		if (!isEmpty(alias.getCombinedKey())) {
 			alias.getCombinedKey().forEach(c -> {
-				SearchCriteria combinedCriteria = new SearchCriteria(c.getKey(), condition.getOperation().name(), null,
-						condition.getValueAsString(), null);
-				Function<SearchCriteria, MonkeyCriteria> functionCombined = FILTER_CRITERIA
-						.get(condition.getOperation());
-				MonkeyCriteria combined = functionCombined.apply(combinedCriteria);
+				MonkeyCriteria combined = buildTypedCriteria(c.getKey(), condition.getOperation(),
+						condition.getValueAsString());
 				apply.addOrClause(apply).addOrClause(combined).withPriorityGroup(alias.getAlias());
 			});
 		}

--- a/src/main/java/br/com/monkey/ecx/parser/QueryVisitor.java
+++ b/src/main/java/br/com/monkey/ecx/parser/QueryVisitor.java
@@ -121,22 +121,19 @@ class QueryVisitor<T> extends QueryBaseVisitor<MonkeyCriteria> {
 		switch (operation) {
 		case EQUAL:
 			if (ValueParser.isDateOnly(value)) {
-				return new MonkeyCriteria().andOperator(
-						MonkeyCriteria.where(key).gte(ValueParser.startOfDay(value)),
+				return new MonkeyCriteria().andOperator(MonkeyCriteria.where(key).gte(ValueParser.startOfDay(value)),
 						MonkeyCriteria.where(key).lt(ValueParser.nextDayStartOfDay(value)));
 			}
 
 			if (ValueParser.isDateTimeToMinute(value)) {
-				return new MonkeyCriteria().andOperator(
-						MonkeyCriteria.where(key).gte(ValueParser.startOfMinute(value)),
+				return new MonkeyCriteria().andOperator(MonkeyCriteria.where(key).gte(ValueParser.startOfMinute(value)),
 						MonkeyCriteria.where(key).lt(ValueParser.nextMinute(value)));
 			}
 			return MonkeyCriteria.where(key).is(ValueParser.parseToDate(value));
 
 		case NOT:
 			if (ValueParser.isDateOnly(value)) {
-				return new MonkeyCriteria().orOperator(
-						MonkeyCriteria.where(key).lt(ValueParser.startOfDay(value)),
+				return new MonkeyCriteria().orOperator(MonkeyCriteria.where(key).lt(ValueParser.startOfDay(value)),
 						MonkeyCriteria.where(key).gte(ValueParser.nextDayStartOfDay(value)));
 			}
 			return MonkeyCriteria.where(key).ne(ValueParser.parseToDate(value));


### PR DESCRIPTION
## Tipo da Alteração

- [ ] Bugfix
- [x] New Feature
- [ ] Enhancement
- [ ] Refactoring

## Descrição
Foi implementado um ajuste no mecanismo de parsing e construção de queries para permitir o filtro por data e hora.

**Principais melhorias**
- Ajuste na gramática (Query.g4) para suportar valores no formato ISO-8601, como:
yyyy-MM-dd
yyyy-MM-ddTHH:mm
yyyy-MM-ddTHH:mm:ss

- Inclusão do tratamento de operadores:

  '>='  
  '<='

- Implementação de conversão dinâmica de valores temporais no QueryVisitor, permitindo identificar automaticamente quando o valor representa uma data ou data/hora.

- Filtros com datas são tratados como intervalo de dia:
 createdAt >= 2025-05-16T00:00:00Z AND < 2025-05-17T00:00:00Z

- Filtros com data e hora e minutos são tratados como intervalo de minuto
createdAt >= 2025-05-16T19:05:00Z AND < 2025-05-16T19:06:00Z

- Filtros com data e hora completa utilizam comparação exata:
createdAt:2025-05-16T19:05:53.571Z

<BR>

**Ajustes estruturais**

- Remoção do FILTER_CRITERIA estático
- Centralização da lógica de construção de critérios em:
  buildTypedCriteria
  buildDefaultCriteria
  buildTemporalCriteria

- Implementação da classe ValueParse para conversão de:
  números
  booleanos
  valores monetários
  Datas e horas


## Como Você Testou a Alteração

**Build**
<img width="1060" height="160" alt="image" src="https://github.com/user-attachments/assets/79cdeb68-1b6f-4c34-bbac-d143d5733dd3" />

- Chamando a API com a data/hora exata no filtro createdAt.
<img width="1131" height="828" alt="image" src="https://github.com/user-attachments/assets/0f017c86-dc8b-4989-9e87-742e31af7dbe" />

- Chamando a API com a data/hora com intervalo de 1 minuto no filtro createdAt.
<img width="1137" height="840" alt="image" src="https://github.com/user-attachments/assets/237f4e6f-96c5-4a87-b802-0272ba6db676" />

- Chamando a API com a data exata
<img width="1127" height="832" alt="image" src="https://github.com/user-attachments/assets/842eed9a-2c73-437d-af7c-b61f35c908c9" />

- Chamando a API com o período entre duas datas no filtro createAt
<img width="1139" height="850" alt="image" src="https://github.com/user-attachments/assets/7708e96a-0ff5-44c9-a931-37e797756a9d" />

- Chamando a API com combinações de filtros sellerGovernmentId, eventType e createdAt
<img width="1131" height="846" alt="image" src="https://github.com/user-attachments/assets/404b768a-072f-49ed-80ce-c511b5cb45c7" />

- Chamando a API com combinações de filtros purchaseId, governmentId, eventType e createdAt
<img width="1125" height="822" alt="image" src="https://github.com/user-attachments/assets/c11360e3-340d-4c95-8e09-b68702721091" />

- Chamando a API com combinações de filtros eventType e invoiceNumber
<img width="1059" height="843" alt="image" src="https://github.com/user-attachments/assets/b1b22939-05dd-454c-adbd-a87eb69a2cf2" />
